### PR TITLE
Center + in button on firefox

### DIFF
--- a/sphinx_collapse_admonitions/_static/collapse_admonitions.css
+++ b/sphinx_collapse_admonitions/_static/collapse_admonitions.css
@@ -11,4 +11,5 @@ button.admonition-button {
     background-color: white;
     border: 1px solid black;
     text-align: center;
+    padding: 0px;
 }


### PR DESCRIPTION
When checking the button in firefox, the + sign was slightly misaligned to the right. Adding the padding rule moves the button to the center.